### PR TITLE
useCountDown and useCountUp API changes

### DIFF
--- a/src/helpers/useCounter.ts
+++ b/src/helpers/useCounter.ts
@@ -1,18 +1,18 @@
 import { useState, useEffect } from "react";
-import { BaseCounter } from "../interfaces";
+import { BaseCounter, BaseOptions } from "../interfaces";
 import { addLeadingZero } from ".";
 
 export const useCounter = (
   min: number,
   max: number,
   isCountingUp: boolean,
-  startPaused?: boolean,
-  onFinish?: () => void
+  options: BaseOptions
 ): BaseCounter => {
   if (min >= max) {
     throw new Error("The min parameter has to be less than the max parameter.");
   }
 
+  const { startPaused, onFinish } = options;
   const [count, setCount] = useState(isCountingUp ? min : max);
   const [paused, setPaused] = useState(startPaused ?? false);
   const [isOver, setIsOver] = useState(false);

--- a/src/hooks/useCountDown.ts
+++ b/src/hooks/useCountDown.ts
@@ -1,9 +1,12 @@
-import { BaseCounter } from "../interfaces";
+import { BaseCounter, BaseOptions } from "../interfaces";
 import { useCounter } from "../helpers";
 
 export const useCountDown = (
   min: number,
   max: number,
-  startPaused?: boolean,
-  onFinish?: () => void
-): BaseCounter => useCounter(min, max, false, startPaused, onFinish);
+  options?: BaseOptions
+): BaseCounter =>
+  useCounter(min, max, false, {
+    startPaused: options?.startPaused,
+    onFinish: options?.onFinish,
+  });

--- a/src/hooks/useCountUp.ts
+++ b/src/hooks/useCountUp.ts
@@ -1,9 +1,12 @@
-import { BaseCounter } from "../interfaces";
+import { BaseCounter, BaseOptions } from "../interfaces";
 import { useCounter } from "../helpers";
 
 export const useCountUp = (
   min: number,
   max: number,
-  startPaused?: boolean,
-  onFinish?: () => void
-): BaseCounter => useCounter(min, max, true, startPaused, onFinish);
+  options?: BaseOptions
+): BaseCounter =>
+  useCounter(min, max, true, {
+    startPaused: options?.startPaused,
+    onFinish: options?.onFinish,
+  });

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -1,3 +1,8 @@
+export interface BaseOptions {
+  startPaused?: boolean;
+  onFinish?: () => void;
+}
+
 export type Zero = {
   withLeadingZero: string;
   withoutLeadingZero: string;


### PR DESCRIPTION
**Before**

```ts
const counter = useCountUp(0, 1, false, () => console.log("Finish"))
```

**Now**

```ts
const counter = useCountUp(0, 1, {
    startPaused: false,
    onFinish: () => console.log("Finish")
})
```